### PR TITLE
Fix eval to allow double quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 node_modules
 .next
+coverage/

--- a/components/weak-aura-editor.tsx
+++ b/components/weak-aura-editor.tsx
@@ -1,4 +1,4 @@
-import { rubyInit } from "@/lib/compiler";
+import { compile, rubyInit } from "@/lib/compiler";
 import Editor from "@monaco-editor/react";
 import { RubyVM } from "@ruby/wasm-wasi";
 import { useCallback, useContext, useEffect } from "react";
@@ -17,15 +17,9 @@ export function WeakAuraEditor({ ruby, onChange }: WeakAuraEditorProps) {
     ruby?.evalAsync(rubyInit);
   }, [ruby]);
 
-  const compile = useCallback(() => {
+  const handleCompile = useCallback(() => {
     if (!ruby) return;
-    const _source = `
-      wa = WeakAura.new(type: WhackAura)
-      wa.instance_eval "${source}"
-      wa.export
-    `;
-
-    ruby?.evalAsync(_source).then((result) => {
+    compile(ruby, source).then((result) => {
       onChange?.(result.toString());
     });
   }, [source, ruby]);
@@ -42,7 +36,7 @@ export function WeakAuraEditor({ ruby, onChange }: WeakAuraEditorProps) {
         />
       </div>
       <div className="flex justify-center space-x-4">
-        <Button onClick={compile} className="w-full">
+        <Button onClick={handleCompile} className="w-full">
           Compile
         </Button>
       </div>

--- a/lib/compiler.test.ts
+++ b/lib/compiler.test.ts
@@ -9,6 +9,12 @@ declare module "vitest" {
   }
 }
 
+const parse = async (vm: RubyVM, code: string) => {
+  const response = await compile(vm, code);
+  const result = response.toString();
+  return JSON.parse(result);
+};
+
 describe("compiler", () => {
   beforeEach(async (context) => {
     const { vm } = await initRuby({ root_uri: "/public/" });
@@ -17,10 +23,20 @@ describe("compiler", () => {
   });
 
   it("returns valid JSON", async ({ vm }) => {
-    const response = await compile(vm, "");
-    const result = response.toString();
-    const json = JSON.parse(result);
-    expect(json).toBeTypeOf("object");
+    expect(await parse(vm, "")).toBeTypeOf("object");
+  });
+
+  it("can deal with single quotes in strings", async ({ vm }) => {
+    expect(
+      await parse(
+        vm,
+        `
+          dynamic_group "Test'er" do
+            action_usable "Test'er'spell"
+          end
+        `
+      )
+    ).toBeTypeOf("object");
   });
 
   describe("debuff_missing", () => {

--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -77,7 +77,7 @@ export const initRuby = async (
 export const compile = async (ruby: RubyVM, source: string) => {
   const _source = `
       wa = WeakAura.new(type: WhackAura)
-      wa.instance_eval "${source}"
+      wa.instance_eval %Q[${source}]
       wa.export
     `;
 


### PR DESCRIPTION
`"${source}"` --> `%Q[${source}]`, because nobody wants to write `'Avenger\\'s Shield'` instead of `"Avenger's Shield"`