### PR TITLE
Add `options` to nodes, allow setting options with defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -20,6 +20,26 @@ jobs:
           npm install
           npx playwright install
           npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  rspec:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - "3.2"
+    name: RSpec tests ruby ${{ matrix.ruby }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run RSpec
+        run: bundle exec rspec public/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,8 @@ on:
       - main
 
 jobs:
-  test:
+  e2e:
     if: github.event.pull_request.draft == false
-    name: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,13 +23,15 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true
   rspec:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
           - "3.2"
-    name: RSpec tests ruby ${{ matrix.ruby }}
+    name: rspec ${{ matrix.ruby }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -44,3 +45,6 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: ./coverage/.resultset.json
+          fail_ci_if_error: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Metrics/BlockLength:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,12 @@ group :development do
   gem 'rubocop'
 end
 
+group :test do
+  gem 'guard'
+  gem 'guard-rspec', require: false
+  gem 'rspec'
+end
+
 gem 'casting'
 gem 'deep_merge'
 gem 'json_pure'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'guard'
   gem 'guard-rspec', require: false
   gem 'rspec'
+  gem 'simplecov', require: false
 end
 
 gem 'casting'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     coderay (1.1.3)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     ffi (1.17.0)
     ffi (1.17.0-x86_64-linux-gnu)
     formatador (1.1.0)
@@ -83,6 +84,12 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     shellany (0.0.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.3.1)
     unicode-display_width (2.5.0)
 
@@ -99,6 +106,7 @@ DEPENDENCIES
   rspec
   rubocop
   ruby_wasm!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,18 +9,65 @@ GEM
   specs:
     ast (2.4.2)
     casting (1.0.2)
+    coderay (1.1.3)
     deep_merge (1.2.2)
+    diff-lcs (1.5.1)
+    ffi (1.17.0)
+    ffi (1.17.0-x86_64-linux-gnu)
+    formatador (1.1.0)
+    guard (2.18.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     json (2.7.1)
     json_pure (2.7.1)
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.10)
+    method_source (1.1.0)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     parallel (1.24.0)
     parser (3.3.0.2)
       ast (~> 2.4.1)
       racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.7.3)
     rainbow (3.1.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     regexp_parser (2.9.0)
     rexml (3.2.6)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -35,6 +82,8 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    shellany (0.0.1)
+    thor (1.3.1)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -44,7 +93,10 @@ PLATFORMS
 DEPENDENCIES
   casting
   deep_merge
+  guard
+  guard-rspec
   json_pure
+  rspec
   rubocop
   ruby_wasm!
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch(/^.+_spec\.rb$/)
+end

--- a/public/node.rb
+++ b/public/node.rb
@@ -76,6 +76,25 @@ class Node # rubocop:disable Style/Documentation,Metrics/ClassLength
     instance_eval(&block)
   end
 
+  class << self
+    attr_accessor :options
+
+    def option(name, default: nil)
+      @options ||= {}
+      options[name] ||= default
+
+      define_method(name) do |value = nil|
+        return options[name] unless value
+
+        options[name] = value
+      end
+    end
+  end
+
+  def options
+    self.class.options
+  end
+
   def id(value = nil)
     return @id unless value
 

--- a/public/node_spec.rb
+++ b/public/node_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require 'casting'
-require 'digest/sha1'
-require 'erb'
-require 'json/pure'
-require 'optparse'
-require_relative 'node'
+require './spec/spec_helper'
 
 RSpec.describe Node do
   describe 'option' do

--- a/public/node_spec.rb
+++ b/public/node_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'casting'
+require 'digest/sha1'
+require 'erb'
+require 'json/pure'
+require 'optparse'
+require_relative 'node'
+
+RSpec.describe Node do
+  describe 'option' do
+    it 'allows setting and modifying the default' do
+      node = Node.new
+      Node.option :foo, default: 'bar'
+      expect(node.options).to eq(foo: 'bar')
+      node.instance_eval do
+        foo 'baz'
+      end
+      expect(node.options).to eq(foo: 'baz')
+    end
+  end
+end

--- a/public/weak_aura/dynamic_group.rb
+++ b/public/weak_aura/dynamic_group.rb
@@ -2,26 +2,28 @@
 
 class WeakAura
   class DynamicGroup < Node # rubocop:disable Metrics/ClassLength,Style/Documentation
+    option :space, default: { x: 2, y: 2 }
+
     def as_json # rubocop:disable Metrics/MethodLength
       custom_grow = <<-LUA
-          function(newPositions, activeRegions)
-            local spaceX = 2
-            local spaceY = 2
-            local gridNum = 4
-            local count, x, y = 0, 0, 0
-            for i, regionData in ipairs(activeRegions) do
-              local region = regionData.region
-              local regionWidth = region.width or 0
-              local regionHeight = region.height or 0
-              if count > 0 and count % gridNum == 0 then
-                y = y + 1
-                x = 0
-              end
-              newPositions[i] = {(regionWidth + spaceX) * x, (regionHeight + spaceY) * y}
-              count = count + 1
-              x = x + 1
+        function(newPositions, activeRegions)
+          local spaceX = #{options[:space][:x]}
+          local spaceY = #{options[:space][:y]}
+          local gridNum = 4
+          local count, x, y = 0, 0, 0
+          for i, regionData in ipairs(activeRegions) do
+            local region = regionData.region
+            local regionWidth = region.width or 0
+            local regionHeight = region.height or 0
+            if count > 0 and count % gridNum == 0 then
+              y = y + 1
+              x = 0
             end
+            newPositions[i] = {(regionWidth + spaceX) * x, (regionHeight + spaceY) * y}
+            count = count + 1
+            x = x + 1
           end
+        end
       LUA
 
       {

--- a/public/weak_aura/dynamic_group_spec.rb
+++ b/public/weak_aura/dynamic_group_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'casting'
+require 'digest/sha1'
+require 'erb'
+require 'json/pure'
+require 'optparse'
+require_relative '../weak_aura'
+require_relative '../whack_aura'
+
+RSpec.describe WeakAura::DynamicGroup do
+  it 'has sane defaults' do
+    wa = WeakAura.new(type: WhackAura)
+    wa.instance_eval do
+      dynamic_group 'Test' do
+      end
+    end
+    group = wa.children.first.as_json
+    expect(group[:customGrow]).to match(/spaceX = 2/)
+    expect(group[:customGrow]).to match(/spaceY = 2/)
+  end
+
+  it 'allows setting spaceX and spaceY of the LUA function' do
+    wa = WeakAura.new(type: WhackAura)
+    wa.instance_eval do
+      dynamic_group 'Test' do
+        space x: 666, y: 666
+      end
+    end
+    group = wa.children.first.as_json
+    expect(group[:grow]).to eq('CUSTOM')
+    expect(group[:customGrow]).to match(/spaceX = 666/)
+    expect(group[:customGrow]).to match(/spaceY = 666/)
+  end
+end

--- a/public/weak_aura/dynamic_group_spec.rb
+++ b/public/weak_aura/dynamic_group_spec.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-require 'casting'
-require 'digest/sha1'
-require 'erb'
-require 'json/pure'
-require 'optparse'
-require_relative '../weak_aura'
-require_relative '../whack_aura'
+require './spec/spec_helper'
 
 RSpec.describe WeakAura::DynamicGroup do
   it 'has sane defaults' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'casting'
+require 'digest/sha1'
+require 'erb'
+require 'json/pure'
+require 'optparse'
+require_relative '../public/weak_aura'
+require_relative '../public/whack_aura'


### PR DESCRIPTION
- Adds the ability to set and access `options` in node instances, with defaults
- Adds `space` option to `WeakAura::DynamicGroup`, setting `spaceX/Y` on the grow function
- Adds rspec 🥳 because not all tests need to be fully e2e